### PR TITLE
fix: db-adapterのtsconfigを修正

### DIFF
--- a/packages/db-adapter/src/executor/types.ts
+++ b/packages/db-adapter/src/executor/types.ts
@@ -4,7 +4,8 @@
  * Types for executing DataSource queries against Prisma
  */
 
-import type { DataSource, FilterOperator } from "@liqueur/protocol";
+// Note: DataSource and FilterOperator are used through the protocol package
+// This file only contains executor-specific type definitions
 
 /**
  * Configuration for DataSource execution

--- a/packages/db-adapter/src/types/index.ts
+++ b/packages/db-adapter/src/types/index.ts
@@ -2,7 +2,7 @@
  * Database Adapter Types
  */
 
-import type { DatabaseMetadata, Table, Column } from "@liqueur/protocol";
+import type { DatabaseMetadata, Table } from "@liqueur/protocol";
 
 /**
  * Database introspector interface

--- a/packages/db-adapter/tsconfig.json
+++ b/packages/db-adapter/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary
- db-adapterのtsconfigをtsconfig.base.jsonから継承するよう修正
- 未使用のインポートを削除（Column, DataSource, FilterOperator）
- ESMモジュールとして正しくビルドされるよう修正

## Test plan
- [x] db-adapterパッケージのビルド成功確認
- [x] household-budgetアプリのビルド成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)